### PR TITLE
Fixed translation of !

### DIFF
--- a/src/Feldspar/Compiler/FromImperative.hs
+++ b/src/Feldspar/Compiler/FromImperative.hs
@@ -221,9 +221,7 @@ compileExpression ConstExpr{..} = compileConstant constExpr
 compileExpression FunctionCall{..} = do
   as <- mapM compileExpression funCallParams
   case () of
-       _ | funName function == "!"
-         -> return [cexp| at($args:as) |]
-         | isInfixFun (funName function)
+       _ | isInfixFun (funName function)
          , [a,b] <- as
          -> mkBinOp a b (funName function)
          | otherwise


### PR DESCRIPTION
The `!` operator comes from the Feldspar function `not` which should be translated to `!` in C.

As far as I can see, the Feldspar operator `!` (array indexing) is not represented as `!` in the imperative representation.

For example, the following program in `feldspar-io` works fine after the change:

``` .haskell
bepa = do
    r <- initRef 100
    l <- getRef r  -- To prevent partial evaluation
    setRef r $ save (parallel l id) ! 23
```
